### PR TITLE
Update ReleaseManager.gd with BN 0.3 Stable URLs

### DIFF
--- a/scripts/ReleaseManager.gd
+++ b/scripts/ReleaseManager.gd
@@ -136,6 +136,11 @@ const _DDA_STABLE_WIN = [
 
 const _BN_STABLE_LINUX = [
 	{
+		"name": "0.3",
+		"url": "https://github.com/cataclysmbnteam/Cataclysm-BN/releases/download/cbn-0.3/cbn-linux-tiles-x64-0.3.tar.gz",
+		"filename": "cbn-linux-tiles-x64-0.3.tar.gz"
+	},
+	{
 		"name": "0.2",
 		"url": "https://github.com/cataclysmbnteam/Cataclysm-BN/releases/download/cbn-0.2/cbn-linux-tiles-x64-0.2.tar.gz",
 		"filename": "cbn-linux-tiles-x64-0.2.tar.gz"
@@ -148,6 +153,11 @@ const _BN_STABLE_LINUX = [
 ]
 
 const _BN_STABLE_WIN = [
+	{
+		"name": "0.3",
+		"url": "https://github.com/cataclysmbnteam/Cataclysm-BN/releases/download/cbn-0.3/cbn-windows-tiles-x64-msvc-0.3.zip",
+		"filename": "cbn-windows-tiles-x64-msvc-0.3.zip"
+	},
 	{
 		"name": "0.2",
 		"url": "https://github.com/cataclysmbnteam/Cataclysm-BN/releases/download/cbn-0.2/cbn-windows-tiles-x64-msvc-0.2.zip",


### PR DESCRIPTION
Added Bright Nights 0.3 stable urls to Release Manager.gd without modifying other files.

All other content URLs for Bright Nights look to be updated for 0.3 already